### PR TITLE
Extract common functionality to form duplicate object exception.

### DIFF
--- a/src/main/java/seedu/address/commons/exceptions/DuplicateObjectException.java
+++ b/src/main/java/seedu/address/commons/exceptions/DuplicateObjectException.java
@@ -6,7 +6,7 @@ package seedu.address.commons.exceptions;
 public class DuplicateObjectException extends RuntimeException {
 
     /**
-     * Constructs a new duplicate person exception.
+     * Constructs a new duplicate object exception.
      *
      * @param pluralNoun Plural form of the object that is duplicated.
      */

--- a/src/main/java/seedu/address/commons/exceptions/DuplicateObjectException.java
+++ b/src/main/java/seedu/address/commons/exceptions/DuplicateObjectException.java
@@ -1,0 +1,16 @@
+package seedu.address.commons.exceptions;
+
+/**
+ * Signals that the operation will result in duplicate Objects.
+ */
+public class DuplicateObjectException extends RuntimeException {
+
+    /**
+     * Constructs a new duplicate person exception.
+     *
+     * @param pluralNoun Plural form of the object that is duplicated.
+     */
+    public DuplicateObjectException(String pluralNoun) {
+        super("Operation would result in duplicate " + pluralNoun);
+    }
+}

--- a/src/main/java/seedu/address/model/pair/exceptions/DuplicatePairException.java
+++ b/src/main/java/seedu/address/model/pair/exceptions/DuplicatePairException.java
@@ -1,0 +1,17 @@
+package seedu.address.model.pair.exceptions;
+
+import seedu.address.commons.exceptions.DuplicateObjectException;
+
+/**
+ * Signals that the operation will result in duplicate Pairs (Pairs are considered duplicates
+ * if its volunteer and elderly have the same identity).
+ */
+public class DuplicatePairException extends DuplicateObjectException {
+
+    /**
+     * Constructs a new duplicate pair exception.
+     */
+    public DuplicatePairException() {
+        super("pairs");
+    }
+}

--- a/src/main/java/seedu/address/model/person/exceptions/DuplicatePersonException.java
+++ b/src/main/java/seedu/address/model/person/exceptions/DuplicatePersonException.java
@@ -1,11 +1,17 @@
 package seedu.address.model.person.exceptions;
 
+import seedu.address.commons.exceptions.DuplicateObjectException;
+
 /**
  * Signals that the operation will result in duplicate Persons (Persons are considered duplicates if they have the same
  * identity).
  */
-public class DuplicatePersonException extends RuntimeException {
+public class DuplicatePersonException extends DuplicateObjectException {
+
+    /**
+     * Constructs a new duplicate person exception.
+     */
     public DuplicatePersonException() {
-        super("Operation would result in duplicate persons");
+        super("persons");
     }
 }


### PR DESCRIPTION
DuplicatePersonException is currently its own class.

This causes repeated code in the future when pairs, elderlies and volunteers are added.

Let's extract the common functionality of duplicate object exceptions into its own class.

Generic classes cannot extend from throwable (Runtime exception) due to type erasure. Let's use regular classes instead.
Fixes #33 