### PR TITLE
Add Volunteer Model

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddElderlyCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddElderlyCommand.java
@@ -5,7 +5,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_AGE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC_ELDERLY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_RISK;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
@@ -28,7 +28,7 @@ public class AddElderlyCommand extends Command {
             + PREFIX_PHONE + "PHONE "
             + PREFIX_EMAIL + "EMAIL "
             + PREFIX_ADDRESS + "ADDRESS "
-            + PREFIX_NRIC + "NRIC "
+            + PREFIX_NRIC_ELDERLY + "NRIC "
             + PREFIX_AGE + "AGE "
             + PREFIX_RISK + "MEDICAL RISK (LOW, MEDIUM or HIGH) "
             + "[" + PREFIX_TAG + "TAG]...\n"
@@ -37,7 +37,7 @@ public class AddElderlyCommand extends Command {
             + PREFIX_PHONE + "98765432 "
             + PREFIX_EMAIL + "johnd@example.com "
             + PREFIX_ADDRESS + "311, Clementi Ave 2, #02-25 "
-            + PREFIX_NRIC + "S1234567A "
+            + PREFIX_NRIC_ELDERLY + "S1234567A "
             + PREFIX_AGE + "69 "
             + PREFIX_RISK + "LOW "
             + PREFIX_TAG + "friends "

--- a/src/main/java/seedu/address/logic/commands/AddPairCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddPairCommand.java
@@ -1,8 +1,8 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_ELDERLY_NRIC;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_VOLUNTEER_NRIC;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC_ELDERLY;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC_VOLUNTEER;
 
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
@@ -17,11 +17,11 @@ public class AddPairCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Pairs an elderly and volunteer in the address book. "
             + "Parameters: "
-            + PREFIX_ELDERLY_NRIC + "ELDERLY ID "
-            + PREFIX_VOLUNTEER_NRIC + "VOLUNTEER ID "
+            + PREFIX_NRIC_ELDERLY + "ELDERLY ID "
+            + PREFIX_NRIC_VOLUNTEER + "VOLUNTEER ID "
             + "Example: " + COMMAND_WORD + " "
-            + PREFIX_ELDERLY_NRIC + "1234 "
-            + PREFIX_VOLUNTEER_NRIC + "5678 ";
+            + PREFIX_NRIC_ELDERLY + "1234 "
+            + PREFIX_NRIC_VOLUNTEER + "5678 ";
 
     public static final String MESSAGE_SUCCESS = "New pair added: %1$s";
 

--- a/src/main/java/seedu/address/logic/commands/AddVolunteerCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddVolunteerCommand.java
@@ -1,0 +1,73 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_AGE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.person.Volunteer;
+
+/**
+ * Adds a volunteer to the database.
+ */
+public class AddVolunteerCommand extends Command {
+
+    public static final String COMMAND_WORD = "add_volunteer";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a volunteer to the database. "
+            + "Parameters: "
+            + PREFIX_NAME + "NAME "
+            + PREFIX_PHONE + "PHONE "
+            + PREFIX_EMAIL + "EMAIL "
+            + PREFIX_ADDRESS + "ADDRESS "
+            + PREFIX_NRIC + "NRIC "
+            + PREFIX_AGE + "AGE "
+            + "[" + PREFIX_TAG + "TAG]...\n"
+            + "Example: " + COMMAND_WORD + " "
+            + PREFIX_NAME + "John Doe "
+            + PREFIX_PHONE + "98765432 "
+            + PREFIX_EMAIL + "johnd@example.com "
+            + PREFIX_ADDRESS + "311, Clementi Ave 2, #02-25 "
+            + PREFIX_NRIC + "S1234567A "
+            + PREFIX_AGE + "20 "
+            + PREFIX_TAG + "new "
+            + PREFIX_TAG + "undergradStudent";
+
+    public static final String MESSAGE_SUCCESS = "New volunteer added: %1$s";
+    public static final String MESSAGE_DUPLICATE_PERSON = "This volunteer already exists in the database";
+
+    private final Volunteer toAdd;
+
+    /**
+     * Creates an AddVolunteerCommand to add to the specified {@code volunteer}
+     */
+    public AddVolunteerCommand(Volunteer volunteer) {
+        requireNonNull(volunteer);
+        toAdd = volunteer;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+
+        if (model.hasPerson(toAdd)) {
+            throw new CommandException(MESSAGE_DUPLICATE_PERSON);
+        }
+
+        model.addPerson(toAdd);
+        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof AddVolunteerCommand // instanceof handles nulls
+                && toAdd.equals(((AddVolunteerCommand) other).toAdd));
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/AddVolunteerCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddVolunteerCommand.java
@@ -5,7 +5,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_AGE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC_VOLUNTEER;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
@@ -26,7 +26,7 @@ public class AddVolunteerCommand extends Command {
             + PREFIX_PHONE + "PHONE "
             + PREFIX_EMAIL + "EMAIL "
             + PREFIX_ADDRESS + "ADDRESS "
-            + PREFIX_NRIC + "NRIC "
+            + PREFIX_NRIC_VOLUNTEER + "NRIC "
             + PREFIX_AGE + "AGE "
             + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " "
@@ -34,7 +34,7 @@ public class AddVolunteerCommand extends Command {
             + PREFIX_PHONE + "98765432 "
             + PREFIX_EMAIL + "johnd@example.com "
             + PREFIX_ADDRESS + "311, Clementi Ave 2, #02-25 "
-            + PREFIX_NRIC + "S1234567A "
+            + PREFIX_NRIC_VOLUNTEER + "S1234567A "
             + PREFIX_AGE + "20 "
             + PREFIX_TAG + "new "
             + PREFIX_TAG + "undergradStudent";

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -10,6 +10,7 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.person.Elderly;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.Volunteer;
 
 /**
  * Deletes a person identified using it's displayed index from the address book.
@@ -25,6 +26,7 @@ public class DeleteCommand extends Command {
 
     public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Person: %1$s";
     public static final String MESSAGE_DELETE_ELDERLY_SUCCESS = "Deleted Elderly: %1$s";
+    public static final String MESSAGE_DELETE_VOLUNTEER_SUCCESS = "Deleted Volunteer: %1$s";
 
     private final Index targetIndex;
 
@@ -45,6 +47,8 @@ public class DeleteCommand extends Command {
         model.deletePerson(personToDelete);
         if (personToDelete instanceof Elderly) {
             return new CommandResult(String.format(MESSAGE_DELETE_ELDERLY_SUCCESS, personToDelete));
+        } else if (personToDelete instanceof Volunteer) {
+            return new CommandResult(String.format(MESSAGE_DELETE_VOLUNTEER_SUCCESS, personToDelete));
         } else {
             return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, personToDelete));
         }

--- a/src/main/java/seedu/address/logic/parser/AddElderlyCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddElderlyCommandParser.java
@@ -5,7 +5,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_AGE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC_ELDERLY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_RISK;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
@@ -38,11 +38,11 @@ public class AddElderlyCommandParser implements Parser<AddElderlyCommand> {
     public AddElderlyCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE,
-                        PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_NRIC, PREFIX_AGE, PREFIX_RISK,
+                        PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_NRIC_ELDERLY, PREFIX_AGE, PREFIX_RISK,
                         PREFIX_TAG);
 
         if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_ADDRESS,
-                PREFIX_PHONE, PREFIX_EMAIL, PREFIX_NRIC, PREFIX_AGE, PREFIX_RISK)
+                PREFIX_PHONE, PREFIX_EMAIL, PREFIX_NRIC_ELDERLY, PREFIX_AGE, PREFIX_RISK)
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String
                     .format(MESSAGE_INVALID_COMMAND_FORMAT,
@@ -53,7 +53,7 @@ public class AddElderlyCommandParser implements Parser<AddElderlyCommand> {
         Phone phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
         Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());
         Address address = ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get());
-        Nric nric = ParserUtil.parseNric(argMultimap.getValue(PREFIX_NRIC).get());
+        Nric nric = ParserUtil.parseNric(argMultimap.getValue(PREFIX_NRIC_ELDERLY).get());
         Age age = ParserUtil.parseAge(argMultimap.getValue(PREFIX_AGE).get());
         RiskLevel risk = ParserUtil.parseRiskLevel(argMultimap.getValue(PREFIX_RISK).get());
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));

--- a/src/main/java/seedu/address/logic/parser/AddPairCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddPairCommandParser.java
@@ -1,8 +1,8 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_ELDERLY_NRIC;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_VOLUNTEER_NRIC;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC_ELDERLY;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC_VOLUNTEER;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -30,15 +30,15 @@ public class AddPairCommandParser implements Parser<AddPairCommand> {
      */
     public AddPairCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_ELDERLY_NRIC, PREFIX_VOLUNTEER_NRIC);
+                ArgumentTokenizer.tokenize(args, PREFIX_NRIC_ELDERLY, PREFIX_NRIC_VOLUNTEER);
 
-        if (!PrefixUtil.arePrefixesPresent(argMultimap, PREFIX_ELDERLY_NRIC, PREFIX_VOLUNTEER_NRIC)
+        if (!PrefixUtil.arePrefixesPresent(argMultimap, PREFIX_NRIC_ELDERLY, PREFIX_NRIC_VOLUNTEER)
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddPairCommand.MESSAGE_USAGE));
         }
 
-        Name elderly = ParserUtil.parseName(argMultimap.getValue(PREFIX_ELDERLY_NRIC).get());
-        Name volunteer = ParserUtil.parseName(argMultimap.getValue(PREFIX_VOLUNTEER_NRIC).get());
+        Name elderly = ParserUtil.parseName(argMultimap.getValue(PREFIX_NRIC_ELDERLY).get());
+        Name volunteer = ParserUtil.parseName(argMultimap.getValue(PREFIX_NRIC_VOLUNTEER).get());
         Phone phone = ParserUtil.parsePhone("88888888");
         Email email = ParserUtil.parseEmail("dummy@email.com");
         Address address = ParserUtil.parseAddress("dummy address");

--- a/src/main/java/seedu/address/logic/parser/AddVolunteerCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddVolunteerCommandParser.java
@@ -10,8 +10,8 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.Set;
-import java.util.stream.Stream;
 
+import seedu.address.commons.util.PrefixUtil;
 import seedu.address.logic.commands.AddVolunteerCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Volunteer;
@@ -39,7 +39,7 @@ public class AddVolunteerCommandParser implements Parser<AddVolunteerCommand> {
                         PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_NRIC_VOLUNTEER, PREFIX_AGE,
                         PREFIX_TAG);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_ADDRESS,
+        if (!PrefixUtil.arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_ADDRESS,
                 PREFIX_PHONE, PREFIX_EMAIL, PREFIX_NRIC_VOLUNTEER, PREFIX_AGE)
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String
@@ -59,13 +59,4 @@ public class AddVolunteerCommandParser implements Parser<AddVolunteerCommand> {
 
         return new AddVolunteerCommand(volunteer);
     }
-
-    /**
-     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
-     * {@code ArgumentMultimap}.
-     */
-    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
-        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
-    }
-
 }

--- a/src/main/java/seedu/address/logic/parser/AddVolunteerCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddVolunteerCommandParser.java
@@ -5,7 +5,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_AGE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC_VOLUNTEER;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
@@ -37,11 +37,11 @@ public class AddVolunteerCommandParser implements Parser<AddVolunteerCommand> {
     public AddVolunteerCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE,
-                        PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_NRIC, PREFIX_AGE,
+                        PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_NRIC_VOLUNTEER, PREFIX_AGE,
                         PREFIX_TAG);
 
         if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_ADDRESS,
-                PREFIX_PHONE, PREFIX_EMAIL, PREFIX_NRIC, PREFIX_AGE)
+                PREFIX_PHONE, PREFIX_EMAIL, PREFIX_NRIC_VOLUNTEER, PREFIX_AGE)
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String
                     .format(MESSAGE_INVALID_COMMAND_FORMAT,
@@ -52,7 +52,7 @@ public class AddVolunteerCommandParser implements Parser<AddVolunteerCommand> {
         Phone phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
         Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());
         Address address = ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get());
-        Nric nric = ParserUtil.parseNric(argMultimap.getValue(PREFIX_NRIC).get());
+        Nric nric = ParserUtil.parseNric(argMultimap.getValue(PREFIX_NRIC_VOLUNTEER).get());
         Age age = ParserUtil.parseAge(argMultimap.getValue(PREFIX_AGE).get());
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
 

--- a/src/main/java/seedu/address/logic/parser/AddVolunteerCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddVolunteerCommandParser.java
@@ -12,7 +12,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import java.util.Set;
 import java.util.stream.Stream;
 
-import seedu.address.logic.commands.AddElderlyCommand;
 import seedu.address.logic.commands.AddVolunteerCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Volunteer;

--- a/src/main/java/seedu/address/logic/parser/AddVolunteerCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddVolunteerCommandParser.java
@@ -45,7 +45,7 @@ public class AddVolunteerCommandParser implements Parser<AddVolunteerCommand> {
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String
                     .format(MESSAGE_INVALID_COMMAND_FORMAT,
-                            AddElderlyCommand.MESSAGE_USAGE));
+                            AddVolunteerCommand.MESSAGE_USAGE));
         }
 
         Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());

--- a/src/main/java/seedu/address/logic/parser/AddVolunteerCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddVolunteerCommandParser.java
@@ -1,0 +1,72 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_AGE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+
+import java.util.Set;
+import java.util.stream.Stream;
+
+import seedu.address.logic.commands.AddElderlyCommand;
+import seedu.address.logic.commands.AddVolunteerCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.Volunteer;
+import seedu.address.model.person.information.Address;
+import seedu.address.model.person.information.Age;
+import seedu.address.model.person.information.Email;
+import seedu.address.model.person.information.Name;
+import seedu.address.model.person.information.Nric;
+import seedu.address.model.person.information.Phone;
+import seedu.address.model.tag.Tag;
+
+/**
+ * Parses input arguments and creates a new AddElderlyCommand object
+ */
+public class AddVolunteerCommandParser implements Parser<AddVolunteerCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the AddElderlyCommand
+     * and returns an AddElderlyCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public AddVolunteerCommand parse(String args) throws ParseException {
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE,
+                        PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_NRIC, PREFIX_AGE,
+                        PREFIX_TAG);
+
+        if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_ADDRESS,
+                PREFIX_PHONE, PREFIX_EMAIL, PREFIX_NRIC, PREFIX_AGE)
+                || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String
+                    .format(MESSAGE_INVALID_COMMAND_FORMAT,
+                            AddElderlyCommand.MESSAGE_USAGE));
+        }
+
+        Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
+        Phone phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
+        Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());
+        Address address = ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get());
+        Nric nric = ParserUtil.parseNric(argMultimap.getValue(PREFIX_NRIC).get());
+        Age age = ParserUtil.parseAge(argMultimap.getValue(PREFIX_AGE).get());
+        Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
+
+        Volunteer volunteer = new Volunteer(name, phone, email, address, nric, age, tagList);
+
+        return new AddVolunteerCommand(volunteer);
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -11,7 +11,8 @@ public class CliSyntax {
     public static final Prefix PREFIX_EMAIL = new Prefix("e/");
     public static final Prefix PREFIX_ADDRESS = new Prefix("a/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
-    public static final Prefix PREFIX_NRIC = new Prefix("nr/");
+    public static final Prefix PREFIX_NRIC_ELDERLY = new Prefix("enr/");
+    public static final Prefix PREFIX_NRIC_VOLUNTEER = new Prefix("vnr/");
     public static final Prefix PREFIX_AGE = new Prefix("ag/");
     public static final Prefix PREFIX_RISK = new Prefix("r/");
 

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -13,8 +13,6 @@ public class CliSyntax {
     public static final Prefix PREFIX_TAG = new Prefix("t/");
     public static final Prefix PREFIX_NRIC_ELDERLY = new Prefix("enr/");
     public static final Prefix PREFIX_NRIC_VOLUNTEER = new Prefix("vnr/");
-    public static final Prefix PREFIX_ELDERLY_NRIC = new Prefix("enr/");
-    public static final Prefix PREFIX_VOLUNTEER_NRIC = new Prefix("vnr/");
     public static final Prefix PREFIX_NRIC = new Prefix("nr/");
     public static final Prefix PREFIX_AGE = new Prefix("ag/");
     public static final Prefix PREFIX_RISK = new Prefix("r/");

--- a/src/main/java/seedu/address/logic/parser/FriendLinkParser.java
+++ b/src/main/java/seedu/address/logic/parser/FriendLinkParser.java
@@ -8,6 +8,7 @@ import java.util.regex.Pattern;
 
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.AddElderlyCommand;
+import seedu.address.logic.commands.AddVolunteerCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
@@ -50,6 +51,9 @@ public class FriendLinkParser {
 
         case AddElderlyCommand.COMMAND_WORD:
             return new AddElderlyCommandParser().parse(arguments);
+
+        case AddVolunteerCommand.COMMAND_WORD:
+            return new AddVolunteerCommandParser().parse(arguments);
 
         case EditCommand.COMMAND_WORD:
             return new EditCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/logic/parser/FriendLinkParser.java
+++ b/src/main/java/seedu/address/logic/parser/FriendLinkParser.java
@@ -8,8 +8,8 @@ import java.util.regex.Pattern;
 
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.AddElderlyCommand;
-import seedu.address.logic.commands.AddVolunteerCommand;
 import seedu.address.logic.commands.AddPairCommand;
+import seedu.address.logic.commands.AddVolunteerCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -134,14 +134,14 @@ public class ParserUtil {
      *
      * @throws ParseException if the given {@code risk} is invalid.
      */
-    public static RiskLevel parseRiskLevel(String risklevel) throws ParseException {
-        requireNonNull(risklevel);
-        String trimmedrisk = risklevel.trim();
-        String upperrisk = trimmedrisk.toUpperCase();
-        if (!RiskLevel.isValidRisk(upperrisk)) {
+    public static RiskLevel parseRiskLevel(String riskLevel) throws ParseException {
+        requireNonNull(riskLevel);
+        String trimmedRisk = riskLevel.trim();
+        String upperRisk = trimmedRisk.toUpperCase();
+        if (!RiskLevel.isValidRisk(upperRisk)) {
             throw new ParseException(RiskLevel.MESSAGE_CONSTRAINTS);
         }
-        return new RiskLevel(upperrisk);
+        return new RiskLevel(upperRisk);
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/Volunteer.java
+++ b/src/main/java/seedu/address/model/person/Volunteer.java
@@ -1,0 +1,76 @@
+package seedu.address.model.person;
+
+import seedu.address.model.person.information.Address;
+import seedu.address.model.person.information.Age;
+import seedu.address.model.person.information.Email;
+import seedu.address.model.person.information.Name;
+import seedu.address.model.person.information.Nric;
+import seedu.address.model.person.information.Phone;
+import seedu.address.model.person.information.RiskLevel;
+import seedu.address.model.tag.Tag;
+
+import java.util.Set;
+
+public class Volunteer extends Person {
+    private final Nric nric;
+    private final Age age;
+    public Volunteer(Name name, Phone phone, Email email,
+                     Address address, Nric nric, Age age, Set<Tag> tags) {
+        super(name, phone, email, address, tags);
+        this.nric = nric;
+        this.age = age;
+    }
+
+    public Nric getNric() {
+        return nric;
+    }
+
+    public Age getAge() {
+        return age;
+    }
+
+    public boolean isSamePerson(Volunteer otherVolunteer) {
+        if (this == otherVolunteer) {
+            return true;
+        }
+        return super.isSamePerson(otherVolunteer) && getNric().equals(otherVolunteer.getNric());
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if (!(other instanceof Volunteer)) {
+            return false;
+        }
+        Volunteer otherVolunteer = (Volunteer) other;
+        return super.equals(otherVolunteer)
+                && getNric().equals(otherVolunteer.getNric())
+                && getAge().equals(otherVolunteer.getAge());
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder builder = new StringBuilder();
+        builder.append(getName())
+                .append("; Phone: ")
+                .append(getPhone())
+                .append("; Email: ")
+                .append(getEmail())
+                .append("; Address: ")
+                .append(getAddress())
+                .append("; NRIC: ")
+                .append(getNric())
+                .append("; Age: ")
+                .append(getAge());
+
+        Set<Tag> tags = getTags();
+        if (!tags.isEmpty()) {
+            builder.append("; Tags: ");
+            tags.forEach(builder::append);
+        }
+        return builder.toString();
+    }
+
+}

--- a/src/main/java/seedu/address/model/person/Volunteer.java
+++ b/src/main/java/seedu/address/model/person/Volunteer.java
@@ -1,5 +1,7 @@
 package seedu.address.model.person;
 
+import java.util.Set;
+
 import seedu.address.model.person.information.Address;
 import seedu.address.model.person.information.Age;
 import seedu.address.model.person.information.Email;
@@ -8,11 +10,16 @@ import seedu.address.model.person.information.Nric;
 import seedu.address.model.person.information.Phone;
 import seedu.address.model.tag.Tag;
 
-import java.util.Set;
-
+/**
+ * Represents an Volunteer in the database.
+ * Guarantees: details are present and not null, field values are validated, immutable.
+ */
 public class Volunteer extends Person {
     private final Nric nric;
     private final Age age;
+    /**
+     * Every field must be present and not null.
+     */
     public Volunteer(Name name, Phone phone, Email email,
                      Address address, Nric nric, Age age, Set<Tag> tags) {
         super(name, phone, email, address, tags);
@@ -28,6 +35,12 @@ public class Volunteer extends Person {
         return age;
     }
 
+    /**
+     * Returns true if both volunteer have the same name and NRIC.
+     * This defines a weaker notion of equality between two volunteers.
+     * Used to detect if the new volunteer is "Duplicate" of existing ones
+     * in the database.
+     */
     public boolean isSamePerson(Volunteer otherVolunteer) {
         if (this == otherVolunteer) {
             return true;

--- a/src/main/java/seedu/address/model/person/Volunteer.java
+++ b/src/main/java/seedu/address/model/person/Volunteer.java
@@ -6,7 +6,6 @@ import seedu.address.model.person.information.Email;
 import seedu.address.model.person.information.Name;
 import seedu.address.model.person.information.Nric;
 import seedu.address.model.person.information.Phone;
-import seedu.address.model.person.information.RiskLevel;
 import seedu.address.model.tag.Tag;
 
 import java.util.Set;

--- a/src/test/java/seedu/address/logic/commands/AddPairCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddPairCommandTest.java
@@ -82,7 +82,7 @@ public class AddPairCommandTest {
     /**
      * A default model stub that have all the methods failing.
      */
-    public static class ModelStub implements Model {
+    private static class ModelStub implements Model {
         @Override
         public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
             throw new AssertionError("This method should not be called.");
@@ -144,16 +144,6 @@ public class AddPairCommandTest {
         }
 
         @Override
-        public ObservableList<Person> getFilteredPersonList() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void updateFilteredPersonList(Predicate<Person> predicate) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
         public void addPair(Pair pair) {
             throw new AssertionError("This method should not be called.");
         }
@@ -170,6 +160,16 @@ public class AddPairCommandTest {
 
         @Override
         public void setPair(Pair target, Pair editedPair) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ObservableList<Person> getFilteredPersonList() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void updateFilteredPersonList(Predicate<Person> predicate) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/address/logic/commands/AddPairCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddPairCommandTest.java
@@ -6,20 +6,14 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
 
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
 
-import javafx.collections.ObservableList;
-import seedu.address.commons.core.GuiSettings;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.FriendlyLink;
-import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyFriendlyLink;
-import seedu.address.model.ReadOnlyUserPrefs;
 import seedu.address.model.pair.Pair;
 import seedu.address.model.person.Person;
 import seedu.address.testutil.PairBuilder;

--- a/src/test/java/seedu/address/logic/commands/AddPairCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddPairCommandTest.java
@@ -47,7 +47,7 @@ public class AddPairCommandTest {
     public void execute_duplicatePair_throwsCommandException() {
         Pair validPair = new PairBuilder().build();
         AddPairCommand addPairCommand = new AddPairCommand(validPair);
-        ModelStub modelStub = new ModelStubWithPair(validPair);
+        CommandTestUtil.ModelStub modelStub = new ModelStubWithPair(validPair);
 
         assertThrows(CommandException.class,
                 AddPairCommand.MESSAGE_DUPLICATE_PAIR, () -> addPairCommand.execute(modelStub));
@@ -80,114 +80,9 @@ public class AddPairCommandTest {
     }
 
     /**
-     * A default model stub that have all of the methods failing.
-     */
-    private class ModelStub implements Model {
-        @Override
-        public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ReadOnlyUserPrefs getUserPrefs() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public GuiSettings getGuiSettings() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setGuiSettings(GuiSettings guiSettings) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public Path getFriendlyLinkFilePath() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setFriendlyLinkFilePath(Path addressBookFilePath) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void addPerson(Person person) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setFriendlyLink(ReadOnlyFriendlyLink newData) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ReadOnlyFriendlyLink getFriendlyLink() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public boolean hasPerson(Person person) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void deletePerson(Person target) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setPerson(Person target, Person editedPerson) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void addPair(Pair pair) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public boolean hasPair(Pair pair) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void deletePair(Pair target) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setPair(Pair target, Pair editedPair) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ObservableList<Person> getFilteredPersonList() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void updateFilteredPersonList(Predicate<Person> predicate) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ObservableList<Pair> getFilteredPairList() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void updateFilteredPairList(Predicate<Pair> predicate) {
-            throw new AssertionError("This method should not be called.");
-        }
-    }
-
-    /**
      * A Model stub that contains a single pair.
      */
-    private class ModelStubWithPair extends ModelStub {
+    private class ModelStubWithPair extends CommandTestUtil.ModelStub {
         private final Pair pair;
 
         ModelStubWithPair(Pair pair) {
@@ -205,7 +100,7 @@ public class AddPairCommandTest {
     /**
      * A Model stub that always accept the pair being added.
      */
-    private class ModelStubAcceptingPairAdded extends ModelStub {
+    private class ModelStubAcceptingPairAdded extends CommandTestUtil.ModelStub {
         final ArrayList<Pair> pairsAdded = new ArrayList<>();
 
         @Override

--- a/src/test/java/seedu/address/logic/commands/AddVolunteerCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddVolunteerCommandTest.java
@@ -1,0 +1,67 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.person.Volunteer;
+import seedu.address.testutil.VolunteerBuilder;
+
+public class AddVolunteerCommandTest {
+
+    @Test
+    public void constructor_nullVolunteer_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new AddVolunteerCommand(null));
+    }
+
+    @Test
+    public void execute_volunteerAcceptedByModel_addSuccessful() throws Exception {
+        CommandTestUtil.ModelStubAcceptingPersonAdded modelStub = new CommandTestUtil.ModelStubAcceptingPersonAdded();
+        Volunteer validVolunteer = new VolunteerBuilder().build();
+
+        CommandResult commandResult = new AddVolunteerCommand(validVolunteer).execute(modelStub);
+
+        assertEquals(String.format(AddVolunteerCommand.MESSAGE_SUCCESS, validVolunteer),
+                commandResult.getFeedbackToUser());
+        assertEquals(Arrays.asList(validVolunteer), modelStub.personsAdded);
+    }
+
+    @Test
+    public void execute_duplicatePerson_throwsCommandException() {
+        Volunteer validVolunteer = new VolunteerBuilder().build();
+        AddVolunteerCommand addCommand = new AddVolunteerCommand(validVolunteer);
+        CommandTestUtil.ModelStub modelStub = new CommandTestUtil.ModelStubWithPerson(validVolunteer);
+
+        assertThrows(CommandException.class,
+                AddVolunteerCommand.MESSAGE_DUPLICATE_PERSON, () -> addCommand.execute(modelStub));
+    }
+
+    @Test
+    public void equals() {
+        Volunteer alice = new VolunteerBuilder().withName("Alice").build();
+        Volunteer bob = new VolunteerBuilder().withName("Bob").build();
+        AddVolunteerCommand addAliceCommand = new AddVolunteerCommand(alice);
+        AddVolunteerCommand addBobCommand = new AddVolunteerCommand(bob);
+
+        // same object -> returns true
+        assertEquals(addAliceCommand, addAliceCommand);
+
+        // same values -> returns true
+        AddVolunteerCommand addAliceCommandCopy = new AddVolunteerCommand(alice);
+        assertEquals(addAliceCommand, addAliceCommandCopy);
+
+        // different types -> returns false
+        assertNotEquals(1, addAliceCommand);
+
+        // null -> returns false
+        assertNotEquals(null, addAliceCommand);
+
+        // different person -> returns false
+        assertNotEquals(addAliceCommand, addBobCommand);
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -4,12 +4,12 @@ import static java.util.Objects.requireNonNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC_ELDERLY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC_ELDERLY;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC_VOLUNTEER;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC_VOLUNTEER;
 import static seedu.address.testutil.Assert.assertThrows;
 
 import java.nio.file.Path;
@@ -165,7 +165,7 @@ public class CommandTestUtil {
     /**
      * A default model stub that have all the methods failing.
      */
-    static public class ModelStub implements Model {
+    public static class ModelStub implements Model {
         @Override
         public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
             throw new AssertionError("This method should not be called.");
@@ -270,7 +270,7 @@ public class CommandTestUtil {
     /**
      * A Model stub that contains a single person.
      */
-    static public class ModelStubWithPerson extends ModelStub {
+    public static class ModelStubWithPerson extends ModelStub {
         private final Person person;
 
         ModelStubWithPerson(Person person) {
@@ -288,7 +288,7 @@ public class CommandTestUtil {
     /**
      * A Model stub that always accept the person being added.
      */
-    static public class ModelStubAcceptingPersonAdded extends ModelStub {
+    public static class ModelStubAcceptingPersonAdded extends ModelStub {
         final ArrayList<Person> personsAdded = new ArrayList<>();
 
         @Override

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.commands;
 
+import static java.util.Objects.requireNonNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
@@ -9,14 +10,20 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.testutil.Assert.assertThrows;
 
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.Predicate;
 
+import javafx.collections.ObservableList;
+import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.FriendlyLink;
 import seedu.address.model.Model;
+import seedu.address.model.ReadOnlyFriendlyLink;
+import seedu.address.model.ReadOnlyUserPrefs;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
@@ -147,5 +154,120 @@ public class CommandTestUtil {
 
         assertEquals(1, model.getFilteredPersonList().size());
     }
+    /**
+     * A default model stub that have all the methods failing.
+     */
+    static public class ModelStub implements Model {
+        @Override
+        public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
+            throw new AssertionError("This method should not be called.");
+        }
 
+        @Override
+        public ReadOnlyUserPrefs getUserPrefs() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public GuiSettings getGuiSettings() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setGuiSettings(GuiSettings guiSettings) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public Path getFriendlyLinkFilePath() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setFriendlyLinkFilePath(Path addressBookFilePath) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void addPerson(Person person) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setFriendlyLink(ReadOnlyFriendlyLink newData) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ReadOnlyFriendlyLink getFriendlyLink() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean hasPerson(Person person) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void deletePerson(Person target) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setPerson(Person target, Person editedPerson) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ObservableList<Person> getFilteredPersonList() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void updateFilteredPersonList(Predicate<Person> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+    }
+
+    /**
+     * A Model stub that contains a single person.
+     */
+    static public class ModelStubWithPerson extends ModelStub {
+        private final Person person;
+
+        ModelStubWithPerson(Person person) {
+            requireNonNull(person);
+            this.person = person;
+        }
+
+        @Override
+        public boolean hasPerson(Person person) {
+            requireNonNull(person);
+            return this.person.isSamePerson(person);
+        }
+    }
+
+    /**
+     * A Model stub that always accept the person being added.
+     */
+    static public class ModelStubAcceptingPersonAdded extends ModelStub {
+        final ArrayList<Person> personsAdded = new ArrayList<>();
+
+        @Override
+        public boolean hasPerson(Person person) {
+            requireNonNull(person);
+            return personsAdded.stream().anyMatch(person::isSamePerson);
+        }
+
+        @Override
+        public void addPerson(Person person) {
+            requireNonNull(person);
+            personsAdded.add(person);
+        }
+
+        @Override
+        public ReadOnlyFriendlyLink getFriendlyLink() {
+            return new FriendlyLink();
+        }
+    }
 }

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -4,12 +4,12 @@ import static java.util.Objects.requireNonNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_ELDERLY_NRIC;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC_ELDERLY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_VOLUNTEER_NRIC;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC_VOLUNTEER;
 import static seedu.address.testutil.Assert.assertThrows;
 
 import java.nio.file.Path;
@@ -26,6 +26,7 @@ import seedu.address.model.FriendlyLink;
 import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyFriendlyLink;
 import seedu.address.model.ReadOnlyUserPrefs;
+import seedu.address.model.pair.Pair;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
@@ -77,10 +78,10 @@ public class CommandTestUtil {
     public static final String TAG_DESC_FRIEND = " " + PREFIX_TAG + VALID_TAG_FRIEND;
     public static final String TAG_DESC_HUSBAND = " " + PREFIX_TAG + VALID_TAG_HUSBAND;
 
-    public static final String ELDERLY_DESC_AMY = " " + PREFIX_ELDERLY_NRIC + VALID_NAME_AMY;
-    public static final String ELDERLY_DESC_BOB = " " + PREFIX_ELDERLY_NRIC + VALID_NAME_BOB;
-    public static final String VOLUNTEER_DESC_AMY = " " + PREFIX_VOLUNTEER_NRIC + VALID_NAME_AMY;
-    public static final String VOLUNTEER_DESC_BOB = " " + PREFIX_VOLUNTEER_NRIC + VALID_NAME_BOB;
+    public static final String ELDERLY_DESC_AMY = " " + PREFIX_NRIC_ELDERLY + VALID_NAME_AMY;
+    public static final String ELDERLY_DESC_BOB = " " + PREFIX_NRIC_ELDERLY + VALID_NAME_BOB;
+    public static final String VOLUNTEER_DESC_AMY = " " + PREFIX_NRIC_VOLUNTEER + VALID_NAME_AMY;
+    public static final String VOLUNTEER_DESC_BOB = " " + PREFIX_NRIC_VOLUNTEER + VALID_NAME_BOB;
 
     public static final String INVALID_NAME_DESC = " " + PREFIX_NAME + "James&"; // '&' not allowed in names
     public static final String INVALID_PHONE_DESC = " " + PREFIX_PHONE + "911a"; // 'a' not allowed in phones
@@ -232,6 +233,36 @@ public class CommandTestUtil {
 
         @Override
         public void updateFilteredPersonList(Predicate<Person> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void addPair(Pair pair) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean hasPair(Pair pair) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void deletePair(Pair target) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setPair(Pair target, Pair editedPair) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ObservableList<Pair> getFilteredPairList() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void updateFilteredPairList(Predicate<Pair> predicate) {
             throw new AssertionError("This method should not be called.");
         }
     }

--- a/src/test/java/seedu/address/model/person/VolunteerTest.java
+++ b/src/test/java/seedu/address/model/person/VolunteerTest.java
@@ -1,0 +1,110 @@
+package seedu.address.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_AGE_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NRIC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NRIC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
+import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalVolunteers.ALICE;
+import static seedu.address.testutil.TypicalVolunteers.BOB;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.testutil.VolunteerBuilder;
+import seedu.address.testutil.VolunteerBuilder;
+
+public class VolunteerTest {
+
+    @Test
+    public void asObservableList_modifyList_throwsUnsupportedOperationException() {
+        Person person = new VolunteerBuilder().build();
+        assertThrows(UnsupportedOperationException.class, () -> person.getTags().remove(0));
+    }
+
+    @Test
+    public void isSamePerson() {
+        // same object -> returns true
+        assertTrue(ALICE.isSamePerson(ALICE));
+
+        // null -> returns false
+        assertFalse(ALICE.isSamePerson(null));
+
+        // same name, same nric, all other attributes different -> returns true
+        Volunteer editedAlice = new VolunteerBuilder(ALICE).withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB)
+                .withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND).build();
+        assertTrue(ALICE.isSamePerson(editedAlice));
+
+        // same name, different nric, all other attributes different -> returns true
+        editedAlice = new VolunteerBuilder(ALICE).withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB)
+                .withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND).withNric(VALID_NRIC_BOB).build();
+        assertFalse(ALICE.isSamePerson(editedAlice));
+
+        // different name, all other attributes same -> returns false
+        editedAlice = new VolunteerBuilder(ALICE).withName(VALID_NAME_BOB).build();
+        assertFalse(ALICE.isSamePerson(editedAlice));
+
+        // name differs in case, all other attributes same -> returns false
+        Person editedBob = new VolunteerBuilder(BOB).withName(VALID_NAME_BOB.toLowerCase()).build();
+        assertFalse(BOB.isSamePerson(editedBob));
+
+        // name has trailing spaces, all other attributes same -> returns false
+        String nameWithTrailingSpaces = VALID_NAME_BOB + " ";
+        editedBob = new VolunteerBuilder(BOB).withName(nameWithTrailingSpaces).build();
+        assertFalse(BOB.isSamePerson(editedBob));
+    }
+
+    @Test
+    public void equals() {
+        // same values -> returns true
+        Person aliceCopy = new VolunteerBuilder(ALICE).build();
+        assertEquals(ALICE, aliceCopy);
+
+        // same object -> returns true
+        assertEquals(ALICE, ALICE);
+
+        // null -> returns false
+        assertNotEquals(null, ALICE);
+
+        // different type -> returns false
+        assertNotEquals(5, ALICE);
+
+        // different person -> returns false
+        assertNotEquals(ALICE, BOB);
+
+        // different name -> returns false
+        Person editedAlice = new VolunteerBuilder(ALICE).withName(VALID_NAME_BOB).build();
+        assertNotEquals(ALICE, editedAlice);
+
+        // different phone -> returns false
+        editedAlice = new VolunteerBuilder(ALICE).withPhone(VALID_PHONE_BOB).build();
+        assertNotEquals(ALICE, editedAlice);
+
+        // different email -> returns false
+        editedAlice = new VolunteerBuilder(ALICE).withEmail(VALID_EMAIL_BOB).build();
+        assertNotEquals(ALICE, editedAlice);
+
+        // different address -> returns false
+        editedAlice = new VolunteerBuilder(ALICE).withAddress(VALID_ADDRESS_BOB).build();
+        assertNotEquals(ALICE, editedAlice);
+
+        // different age -> returns false
+        editedAlice = new VolunteerBuilder(ALICE).withAge(VALID_AGE_BOB).build();
+        assertNotEquals(ALICE, editedAlice);
+
+        // different nric -> returns false
+        editedAlice = new VolunteerBuilder(ALICE).withNric(VALID_NRIC_BOB).build();
+        assertNotEquals(ALICE, editedAlice);
+
+        // different tags -> returns false
+        editedAlice = new VolunteerBuilder(ALICE).withTags(VALID_TAG_HUSBAND).build();
+        assertNotEquals(ALICE, editedAlice);
+    }
+}

--- a/src/test/java/seedu/address/model/person/VolunteerTest.java
+++ b/src/test/java/seedu/address/model/person/VolunteerTest.java
@@ -8,7 +8,6 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_AGE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_NRIC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NRIC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
@@ -18,7 +17,6 @@ import static seedu.address.testutil.TypicalVolunteers.BOB;
 
 import org.junit.jupiter.api.Test;
 
-import seedu.address.testutil.VolunteerBuilder;
 import seedu.address.testutil.VolunteerBuilder;
 
 public class VolunteerTest {

--- a/src/test/java/seedu/address/model/person/information/NricTest.java
+++ b/src/test/java/seedu/address/model/person/information/NricTest.java
@@ -13,7 +13,7 @@ class NricTest {
     }
 
     @Test
-    public void constructor_invalidAge_throwsIllegalArgumentException() {
+    public void constructor_invalidNric_throwsIllegalArgumentException() {
         String invalidNric = "";
         assertThrows(IllegalArgumentException.class, () -> new Nric(invalidNric));
     }

--- a/src/test/java/seedu/address/testutil/PairUtil.java
+++ b/src/test/java/seedu/address/testutil/PairUtil.java
@@ -1,7 +1,7 @@
 package seedu.address.testutil;
 
-import static seedu.address.logic.parser.CliSyntax.PREFIX_ELDERLY_NRIC;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_VOLUNTEER_NRIC;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC_ELDERLY;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC_VOLUNTEER;
 
 import seedu.address.logic.commands.AddPairCommand;
 import seedu.address.model.pair.Pair;
@@ -22,8 +22,8 @@ public class PairUtil {
      * Returns the part of command string for the given {@code person}'s details.
      */
     public static String getPairDetails(Pair pair) {
-        String sb = PREFIX_ELDERLY_NRIC + pair.getElderly().getName().fullName + " "
-                + PREFIX_VOLUNTEER_NRIC + pair.getVolunteer().getName().fullName + " ";
+        String sb = PREFIX_NRIC_ELDERLY + pair.getElderly().getName().fullName + " "
+                + PREFIX_NRIC_VOLUNTEER + pair.getVolunteer().getName().fullName + " ";
         return sb;
     }
 }

--- a/src/test/java/seedu/address/testutil/PersonBuilderScaffold.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilderScaffold.java
@@ -1,0 +1,101 @@
+package seedu.address.testutil;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import seedu.address.model.person.Person;
+import seedu.address.model.person.information.Address;
+import seedu.address.model.person.information.Email;
+import seedu.address.model.person.information.Name;
+import seedu.address.model.person.information.Phone;
+import seedu.address.model.tag.Tag;
+import seedu.address.model.util.SampleDataUtil;
+
+/**
+ * A utility class to help with building Person objects.
+ */
+public abstract class PersonBuilderScaffold<T extends PersonBuilderScaffold<T>> {
+
+    public static final String DEFAULT_NAME = "Amy Bee";
+    public static final String DEFAULT_PHONE = "85355255";
+    public static final String DEFAULT_EMAIL = "amy@gmail.com";
+    public static final String DEFAULT_ADDRESS = "123, Jurong West Ave 6, #08-111";
+
+    protected Name name;
+    protected Phone phone;
+    protected Email email;
+    protected Address address;
+    protected Set<Tag> tags;
+
+    /**
+     * Creates a {@code PersonBuilder} with the default details.
+     */
+    protected PersonBuilderScaffold() {
+        name = new Name(DEFAULT_NAME);
+        phone = new Phone(DEFAULT_PHONE);
+        email = new Email(DEFAULT_EMAIL);
+        address = new Address(DEFAULT_ADDRESS);
+        tags = new HashSet<>();
+    }
+
+    /**
+     * Initializes the PersonBuilder with the data of {@code personToCopy}.
+     */
+    protected PersonBuilderScaffold(Person personToCopy) {
+        name = personToCopy.getName();
+        phone = personToCopy.getPhone();
+        email = personToCopy.getEmail();
+        address = personToCopy.getAddress();
+        tags = new HashSet<>(personToCopy.getTags());
+    }
+
+    private T castSelf() {
+        @SuppressWarnings("unchecked") T casted = (T) this;
+        return casted;
+    }
+
+    /**
+     * Sets the {@code Name} of the {@code Person} that we are building.
+     */
+    public T withName(String name) {
+        this.name = new Name(name);
+        return castSelf();
+    }
+
+    /**
+     * Parses the {@code tags} into a {@code Set<Tag>} and set it to the {@code Person} that we are building.
+     */
+    public T withTags(String ... tags) {
+        this.tags = SampleDataUtil.getTagSet(tags);
+        return castSelf();
+    }
+
+    /**
+     * Sets the {@code Address} of the {@code Person} that we are building.
+     */
+    public T withAddress(String address) {
+        this.address = new Address(address);
+        return castSelf();
+    }
+
+    /**
+     * Sets the {@code Phone} of the {@code Person} that we are building.
+     */
+    public T withPhone(String phone) {
+        this.phone = new Phone(phone);
+        return castSelf();
+    }
+
+    /**
+     * Sets the {@code Email} of the {@code Person} that we are building.
+     */
+    public T withEmail(String email) {
+        this.email = new Email(email);
+        return castSelf();
+    }
+
+    public Person build() {
+        return new Person(name, phone, email, address, tags);
+    }
+
+}

--- a/src/test/java/seedu/address/testutil/TypicalVolunteers.java
+++ b/src/test/java/seedu/address/testutil/TypicalVolunteers.java
@@ -1,0 +1,73 @@
+package seedu.address.testutil;
+
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_AGE_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_AGE_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NRIC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NRIC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import seedu.address.model.FriendlyLink;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.Volunteer;
+
+/**
+ * A utility class containing a list of {@code Person} objects to be used in tests.
+ */
+public class TypicalVolunteers {
+
+    public static final Volunteer ALICE = new VolunteerBuilder().withName("Alice Pauline")
+            .withAddress("123, Jurong West Ave 6, #08-111").withEmail("alice@example.com")
+            .withPhone("94351253")
+            .withTags("friends").withAge("20").withNric("S9673908G").build();
+    public static final Volunteer BENSON = new VolunteerBuilder().withName("Benson Meier")
+            .withAddress("311, Clementi Ave 2, #02-25")
+            .withEmail("johnd@example.com").withPhone("98765432")
+            .withTags("owesMoney", "friends").withAge("23").withNric("S6878241D").build();
+    public static final Volunteer CARL = new VolunteerBuilder().withName("Carl Kurz").withPhone("95352563")
+            .withEmail("heinz@example.com").withAddress("wall street").withAge("31").withNric("S3634466J").build();
+    public static final Volunteer DANIEL = new VolunteerBuilder().withName("Daniel Meier").withPhone("87652533")
+            .withEmail("cornelia@example.com").withAddress("10th street").withTags("friends").withAge("25")
+            .withNric("S0203151E").build();
+    public static final Volunteer ELLE = new VolunteerBuilder().withName("Elle Meyer").withPhone("9482224")
+            .withEmail("werner@example.com").withAddress("michegan ave").withAge("28")
+            .withNric("S7238791J").build();
+    public static final Volunteer FIONA = new VolunteerBuilder().withName("Fiona Kunz").withPhone("9482427")
+            .withEmail("lydia@example.com").withAddress("little tokyo").withAge("26")
+            .withNric("S3576311B").build();
+    public static final Volunteer GEORGE = new VolunteerBuilder().withName("George Best").withPhone("9482442")
+            .withEmail("anna@example.com").withAddress("4th street").withAge("24")
+            .withNric("S1262951F").build();
+
+    // Manually added
+    public static final Volunteer HOON = new VolunteerBuilder().withName("Hoon Meier").withPhone("8482424")
+            .withEmail("stefan@example.com").withAddress("little india").build();
+    public static final Volunteer IDA = new VolunteerBuilder().withName("Ida Mueller").withPhone("8482131")
+            .withEmail("hans@example.com").withAddress("chicago ave").build();
+
+    // Manually added - Person's details found in {@code CommandTestUtil}
+    public static final Volunteer AMY = new VolunteerBuilder().withName(VALID_NAME_AMY).withPhone(VALID_PHONE_AMY)
+            .withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY).withTags(VALID_TAG_FRIEND)
+            .withNric(VALID_NRIC_AMY).withAge(VALID_AGE_AMY).build();
+    public static final Volunteer BOB = new VolunteerBuilder().withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
+            .withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND)
+            .withNric(VALID_NRIC_BOB).withAge(VALID_AGE_BOB).build();
+
+    private TypicalVolunteers() {} // prevents instantiation
+
+    public static List<Volunteer> getTypicalVolunteers() {
+        return new ArrayList<>(Arrays.asList(ALICE, BENSON, CARL, DANIEL, ELLE, FIONA, GEORGE));
+    }
+}

--- a/src/test/java/seedu/address/testutil/TypicalVolunteers.java
+++ b/src/test/java/seedu/address/testutil/TypicalVolunteers.java
@@ -19,8 +19,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import seedu.address.model.FriendlyLink;
-import seedu.address.model.person.Person;
 import seedu.address.model.person.Volunteer;
 
 /**

--- a/src/test/java/seedu/address/testutil/VolunteerBuilder.java
+++ b/src/test/java/seedu/address/testutil/VolunteerBuilder.java
@@ -1,35 +1,47 @@
 package seedu.address.testutil;
 
-import seedu.address.model.person.Person;
 import seedu.address.model.person.Volunteer;
 import seedu.address.model.person.information.Age;
 import seedu.address.model.person.information.Nric;
 
-import java.util.HashSet;
-
+/**
+ * A utility class to help with building Volunteer objects.
+ */
 public class VolunteerBuilder extends PersonBuilderScaffold<VolunteerBuilder> {
     public static final String DEFAULT_AGE = "20";
     public static final String DEFAULT_NRIC = "T1234567I";
     private Age age;
     private Nric nric;
 
+    /**
+     * Creates a {@code VolunteerBuilder} with the default details.
+     */
     public VolunteerBuilder() {
         super();
         this.age = new Age(DEFAULT_AGE);
         this.nric = new Nric(DEFAULT_NRIC);
     }
 
+    /**
+     * Initializes the VolunteerBuilder with the data of {@code volunteerToCopy}.
+     */
     public VolunteerBuilder(Volunteer volunteerToCopy) {
         super(volunteerToCopy);
         age = volunteerToCopy.getAge();
         nric = volunteerToCopy.getNric();
     }
 
+    /**
+     * Sets the {@code Age} of the {@code Volunteer} that we are building.
+     */
     public VolunteerBuilder withAge(String age) {
         this.age = new Age(age);
         return this;
     }
 
+    /**
+     * Sets the {@code Nric} of the {@code Volunteer} that we are building.
+     */
     public VolunteerBuilder withNric(String nric) {
         this.nric = new Nric(nric);
         return this;

--- a/src/test/java/seedu/address/testutil/VolunteerBuilder.java
+++ b/src/test/java/seedu/address/testutil/VolunteerBuilder.java
@@ -1,0 +1,41 @@
+package seedu.address.testutil;
+
+import seedu.address.model.person.Person;
+import seedu.address.model.person.Volunteer;
+import seedu.address.model.person.information.Age;
+import seedu.address.model.person.information.Nric;
+
+import java.util.HashSet;
+
+public class VolunteerBuilder extends PersonBuilderScaffold<VolunteerBuilder> {
+    public static final String DEFAULT_AGE = "20";
+    public static final String DEFAULT_NRIC = "T1234567I";
+    private Age age;
+    private Nric nric;
+
+    public VolunteerBuilder() {
+        super();
+        this.age = new Age(DEFAULT_AGE);
+        this.nric = new Nric(DEFAULT_NRIC);
+    }
+
+    public VolunteerBuilder(Volunteer volunteerToCopy) {
+        super(volunteerToCopy);
+        age = volunteerToCopy.getAge();
+        nric = volunteerToCopy.getNric();
+    }
+
+    public VolunteerBuilder withAge(String age) {
+        this.age = new Age(age);
+        return this;
+    }
+
+    public VolunteerBuilder withNric(String nric) {
+        this.nric = new Nric(nric);
+        return this;
+    }
+
+    public Volunteer build() {
+        return new Volunteer(name, phone, email, address, nric, age, tags);
+    }
+}


### PR DESCRIPTION
Fixes #47, fixes #48 
 
## Added
- New `Volunteer` model
- New `AddVolunteerCommand` and `AddVolunterCommandParser` models
- New tests for `Volunteer` model, including a  `VolunteerBuilder`. (I also added an abstract class called `PersonBuilderScaffold`. This is to allow better inheritance using the builder pattern.)
- Modified name of `PREFIX_ELDERLY_NRIC` and `PREFIX_VOLUNTEER_NRIC` to `PREFIX_NRIC_ELDERLY` and `PREFIX_NRIC_VOLUNTEER`
- Refactored out `ModelStub` to `CommandTestUtil` to minimise code duplication

## Left To Do
- [x] Tests for `AddVolunteerCommand`

## Things to note
- We should probably just add NRIC and age to the `Person` model: right now there's quite a bit of code duplication between the `Volunteer` and `Elderly` classes. Will do in a separate PR probably
- The v1.2 User Guide seems to not be fully in-line with the current implementation: the `add_volunteer` command in the guide is missing `p/`, `t/` and `ag/` (Phone number, tag, and age respectively)
- `delete` command currently is one command for both the elderly and volunteers using the list index. Should break this up into 2 commands using NRIC instead as per the guide. To do in a future PR.
- Still unsure whether we are adding "Medical training" as a tag, or as an attribute to the `Volunteer` class