### PR TITLE
Add Delete Volunteer Command via NRIC

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -8,6 +8,7 @@ public class Messages {
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
+    public static final String MESSAGE_INVALID_VOLUNTEER_NRIC = "The volunteer NRIC provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
 
 }

--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -11,6 +11,7 @@ import seedu.address.model.ReadOnlyFriendlyLink;
 import seedu.address.model.pair.Pair;
 import seedu.address.model.person.Elderly;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.Volunteer;
 
 /**
  * API of the Logic component
@@ -40,7 +41,7 @@ public interface Logic {
     ObservableList<Elderly> getFilteredElderlyList();
 
     /** Returns an unmodifiable view of the filtered list of volunteers */
-    ObservableList<Person> getFilteredVolunteerList();
+    ObservableList<Volunteer> getFilteredVolunteerList();
 
     /** Returns an unmodifiable view of the filtered list of pairs */
     ObservableList<Pair> getFilteredPairList();

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -17,6 +17,7 @@ import seedu.address.model.ReadOnlyFriendlyLink;
 import seedu.address.model.pair.Pair;
 import seedu.address.model.person.Elderly;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.Volunteer;
 import seedu.address.storage.Storage;
 
 /**
@@ -88,7 +89,7 @@ public class LogicManager implements Logic {
         return model.getFilteredElderlyList();
     }
     @Override
-    public ObservableList<Person> getFilteredVolunteerList() {
+    public ObservableList<Volunteer> getFilteredVolunteerList() {
         return model.getFilteredVolunteerList();
     }
     @Override

--- a/src/main/java/seedu/address/logic/commands/DeleteVolunteerCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteVolunteerCommand.java
@@ -16,9 +16,9 @@ public class DeleteVolunteerCommand extends Command {
     public static final String COMMAND_WORD = "delete_volunteer";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Deletes the person identified by their NRIC.\n"
+            + ": Deletes the volunteer identified by their NRIC.\n"
             + "Parameters: NRIC \n"
-            + "Example: " + COMMAND_WORD + " S123456567I";
+            + "Example: " + COMMAND_WORD + " S1234567I";
 
     public static final String MESSAGE_DELETE_SUCCESS = "Deleted Volunteer: %1$s";
 

--- a/src/main/java/seedu/address/logic/commands/DeleteVolunteerCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteVolunteerCommand.java
@@ -1,0 +1,48 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.person.Volunteer;
+import seedu.address.model.person.information.Nric;
+
+/**
+ * Deletes a person identified using it's displayed index from the address book.
+ */
+public class DeleteVolunteerCommand extends Command {
+
+    public static final String COMMAND_WORD = "delete_volunteer";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Deletes the person identified by their NRIC.\n"
+            + "Parameters: NRIC \n"
+            + "Example: " + COMMAND_WORD + " S123456567I";
+
+    public static final String MESSAGE_DELETE_SUCCESS = "Deleted Volunteer: %1$s";
+
+    private final Nric targetNric;
+
+    public DeleteVolunteerCommand(Nric targetNric) {
+        this.targetNric = targetNric;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        Volunteer volunteerToDelete = model.getVolunteerByNric(targetNric);
+        if (volunteerToDelete == null) {
+            throw new CommandException(Messages.MESSAGE_INVALID_VOLUNTEER_NRIC);
+        }
+        model.deleteVolunteer(volunteerToDelete);
+        return new CommandResult(String.format(MESSAGE_DELETE_SUCCESS, volunteerToDelete));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof DeleteVolunteerCommand // instanceof handles nulls
+                && targetNric.equals(((DeleteVolunteerCommand) other).targetNric)); // state check
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/DeleteVolunteerCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteVolunteerCommandParser.java
@@ -1,0 +1,30 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC_VOLUNTEER;
+
+import seedu.address.logic.commands.DeleteVolunteerCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.information.Nric;
+
+/**
+ * Parses input arguments and creates a new DeleteCommand object
+ */
+public class DeleteVolunteerCommandParser implements Parser<DeleteVolunteerCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the DeleteCommand
+     * and returns a DeleteCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public DeleteVolunteerCommand parse(String args) throws ParseException {
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NRIC_VOLUNTEER);
+        if (argMultimap.getValue(PREFIX_NRIC_VOLUNTEER).isEmpty() || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    DeleteVolunteerCommand.MESSAGE_USAGE));
+        }
+        Nric nric = new Nric(argMultimap.getValue(PREFIX_NRIC_VOLUNTEER).get());
+        return new DeleteVolunteerCommand(nric);
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/FriendLinkParser.java
+++ b/src/main/java/seedu/address/logic/parser/FriendLinkParser.java
@@ -13,6 +13,7 @@ import seedu.address.logic.commands.AddVolunteerCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.commands.DeleteVolunteerCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
@@ -61,6 +62,9 @@ public class FriendLinkParser {
 
         case DeleteCommand.COMMAND_WORD:
             return new DeleteCommandParser().parse(arguments);
+
+        case DeleteVolunteerCommand.COMMAND_WORD:
+            return new DeleteVolunteerCommandParser().parse(arguments);
 
         case ClearCommand.COMMAND_WORD:
             return new ClearCommand();

--- a/src/main/java/seedu/address/model/FriendlyLink.java
+++ b/src/main/java/seedu/address/model/FriendlyLink.java
@@ -10,6 +10,8 @@ import seedu.address.model.pair.UniquePairList;
 import seedu.address.model.person.Elderly;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.UniquePersonList;
+import seedu.address.model.person.Volunteer;
+import seedu.address.model.person.information.Nric;
 
 /**
  * Wraps all data at the friendly-link level
@@ -19,7 +21,7 @@ public class FriendlyLink implements ReadOnlyFriendlyLink, ReadOnlyElderly, Read
     // TODO: update generic to volunteer and remove person list
     private final UniquePersonList<Person> persons;
     private final UniquePersonList<Elderly> elderly;
-    private final UniquePersonList<Person> volunteers;
+    private final UniquePersonList<Volunteer> volunteers;
     private final UniquePairList pairs;
 
     /*
@@ -69,8 +71,21 @@ public class FriendlyLink implements ReadOnlyFriendlyLink, ReadOnlyElderly, Read
      * Replaces the contents of the volunteer list with {@code volunteers}.
      * {@code volunteers} must not contain duplicate volunteers.
      */
-    public void setVolunteers(List<Person> volunteers) {
+    public void setVolunteers(List<Volunteer> volunteers) {
         this.volunteers.setPersons(volunteers);
+    }
+
+    /**
+     * Returns the volunteer with the given NRIC, or null otherwise.
+     * @param nric The given NRIC.
+     * @return A Volunteer with the matching NRIC< or null if no volunteer has that NRIC.
+     */
+    public Volunteer getVolunteerByNric(Nric nric) {
+        List<Volunteer> filteredVolunteers = this.volunteers.filter(volunteer -> volunteer.getNric().equals(nric));
+        if (filteredVolunteers.size() == 0) {
+            return null;
+        }
+        return filteredVolunteers.get(0);
     }
 
     /**
@@ -118,7 +133,7 @@ public class FriendlyLink implements ReadOnlyFriendlyLink, ReadOnlyElderly, Read
     /**
      * Returns true if a person with the same identity as {@code person} exists in the friendlyLink cache.
      */
-    public boolean hasVolunteer(Person volunteer) {
+    public boolean hasVolunteer(Volunteer volunteer) {
         requireNonNull(volunteer);
         return volunteers.contains(volunteer);
     }
@@ -143,7 +158,7 @@ public class FriendlyLink implements ReadOnlyFriendlyLink, ReadOnlyElderly, Read
      * Adds a volunteer to the friendlyLink cache.
      * The volunteer must not already exist in the friendlyLink cache.
      */
-    public void addVolunteer(Person p) {
+    public void addVolunteer(Volunteer p) {
         volunteers.add(p);
     }
 
@@ -175,7 +190,7 @@ public class FriendlyLink implements ReadOnlyFriendlyLink, ReadOnlyElderly, Read
      * The volunteer identity of {@code editedPerson} must not be the same as
      * another existing volunteer in the friendlyLink cache.
      */
-    public void setVolunteer(Person target, Person editedPerson) {
+    public void setVolunteer(Volunteer target, Volunteer editedPerson) {
         requireNonNull(editedPerson);
         volunteers.setPerson(target, editedPerson);
     }
@@ -236,7 +251,7 @@ public class FriendlyLink implements ReadOnlyFriendlyLink, ReadOnlyElderly, Read
      * Removes {@code key} from {@code FriendlyLink}.
      * {@code key} must exist in the volunteer's list.
      */
-    public void removeVolunteer(Person key) {
+    public void removeVolunteer(Volunteer key) {
         volunteers.remove(key);
     }
 
@@ -260,7 +275,7 @@ public class FriendlyLink implements ReadOnlyFriendlyLink, ReadOnlyElderly, Read
     }
 
     @Override
-    public ObservableList<Person> getVolunteerList() {
+    public ObservableList<Volunteer> getVolunteerList() {
         return volunteers.asUnmodifiableObservableList();
     }
 

--- a/src/main/java/seedu/address/model/FriendlyLink.java
+++ b/src/main/java/seedu/address/model/FriendlyLink.java
@@ -94,6 +94,8 @@ public class FriendlyLink implements ReadOnlyFriendlyLink, ReadOnlyElderly, Read
     public void resetFriendlyLinkData(ReadOnlyFriendlyLink newData) {
         requireNonNull(newData);
         setPersons(newData.getPersonList());
+        setAllElderly(newData.getElderlyList());
+        setVolunteers(newData.getVolunteerList());
     }
 
     /**

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -9,6 +9,7 @@ import seedu.address.model.pair.Pair;
 import seedu.address.model.person.Elderly;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Volunteer;
+import seedu.address.model.person.information.Nric;
 
 /**
  * The API of the Model component.
@@ -131,6 +132,13 @@ public interface Model {
     void setVolunteer(Volunteer target, Volunteer editedPerson);
 
     /**
+     * Returns the volunteer with the given NRIC, or null otherwise.
+     * @param nric The given NRIC.
+     * @return A Volunteer with the matching NRIC< or null if no volunteer has that NRIC.
+     */
+    Volunteer getVolunteerByNric(Nric nric);
+
+    /**
      * Returns true if a pair with the same identity as {@code pair} exists in the address book.
      */
     boolean hasPair(Pair pair);
@@ -176,7 +184,7 @@ public interface Model {
 
 
     /** Returns an unmodifiable view of the filtered volunteers list */
-    ObservableList<Person> getFilteredVolunteerList();
+    ObservableList<Volunteer> getFilteredVolunteerList();
 
     /**
      * Updates the filter of the filtered volunteers list to filter by the given {@code predicate}.

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -15,6 +15,7 @@ import seedu.address.model.pair.Pair;
 import seedu.address.model.person.Elderly;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Volunteer;
+import seedu.address.model.person.information.Nric;
 
 /**
  * Represents the in-memory model of the friendly link data.
@@ -26,7 +27,7 @@ public class ModelManager implements Model {
     private final UserPrefs userPrefs;
     private final FilteredList<Person> filteredPersons;
     private final FilteredList<Elderly> filteredElderly;
-    private final FilteredList<Person> filteredVolunteers;
+    private final FilteredList<Volunteer> filteredVolunteers;
     private final FilteredList<Pair> filteredPairs;
 
     /**
@@ -167,6 +168,12 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public Volunteer getVolunteerByNric(Nric nric) {
+        requireNonNull(nric);
+        return friendlyLink.getVolunteerByNric(nric);
+    }
+
+    @Override
     public boolean hasPair(Pair pair) {
         requireNonNull(pair);
         return friendlyLink.hasPair(pair);
@@ -230,7 +237,7 @@ public class ModelManager implements Model {
      * {@code versionedFriendlyLink}
      */
     @Override
-    public ObservableList<Person> getFilteredVolunteerList() {
+    public ObservableList<Volunteer> getFilteredVolunteerList() {
         return filteredVolunteers;
     }
 

--- a/src/main/java/seedu/address/model/ReadOnlyFriendlyLink.java
+++ b/src/main/java/seedu/address/model/ReadOnlyFriendlyLink.java
@@ -2,7 +2,9 @@ package seedu.address.model;
 
 import javafx.collections.ObservableList;
 import seedu.address.model.pair.Pair;
+import seedu.address.model.person.Elderly;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.Volunteer;
 
 /**
  * Unmodifiable view of an address book
@@ -14,6 +16,16 @@ public interface ReadOnlyFriendlyLink {
      * This list will not contain any duplicate persons.
      */
     ObservableList<Person> getPersonList();
+    /**
+     * Returns an unmodifiable view of the volunteer list.
+     * This list will not contain any duplicate persons.
+     */
+    ObservableList<Volunteer> getVolunteerList();
+    /**
+     * Returns an unmodifiable view of the elderly list.
+     * This list will not contain any duplicate persons.
+     */
+    ObservableList<Elderly> getElderlyList();
 
     /**
      * Returns an unmodifiable view of the pairs list.

--- a/src/main/java/seedu/address/model/ReadOnlyVolunteer.java
+++ b/src/main/java/seedu/address/model/ReadOnlyVolunteer.java
@@ -1,7 +1,8 @@
 package seedu.address.model;
 
-import javafx.collections.ObservableList;
-import seedu.address.model.person.Person;
+import java.util.List;
+
+import seedu.address.model.person.Volunteer;
 
 /**
  * Unmodifiable list of volunteers
@@ -11,6 +12,6 @@ public interface ReadOnlyVolunteer {
      * Returns an unmodifiable view of the volunteer list.
      * This list will not contain any duplicate volunteers.
      */
-    ObservableList<Person> getVolunteerList();
+    List<Volunteer> getVolunteerList();
 
 }

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -5,9 +5,11 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.Iterator;
 import java.util.List;
+import java.util.function.Predicate;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import javafx.collections.transformation.FilteredList;
 import seedu.address.model.person.exceptions.DuplicatePersonException;
 import seedu.address.model.person.exceptions.PersonNotFoundException;
 
@@ -46,6 +48,16 @@ public class UniquePersonList<T extends Person> implements Iterable<T> {
             throw new DuplicatePersonException();
         }
         internalList.add(toAdd);
+    }
+
+    /**
+     * Returns a filtered list of unique persons using a given predicate.
+     * @param predicate The given predicate.
+     * @return The filtered list of persons.
+     */
+    public FilteredList<T> filter(Predicate<T> predicate) {
+        requireNonNull(predicate);
+        return internalList.filtered(predicate);
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -3,6 +3,7 @@ package seedu.address.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_AGE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC_ELDERLY;
@@ -57,11 +58,8 @@ public class CommandTestUtil {
     public static final String ADDRESS_DESC_AMY = " " + PREFIX_ADDRESS + VALID_ADDRESS_AMY;
     public static final String ADDRESS_DESC_BOB = " " + PREFIX_ADDRESS + VALID_ADDRESS_BOB;
 
-    public static final String NRIC_DESC_AMY = " " + PREFIX_ADDRESS + VALID_NRIC_AMY;
-    public static final String NRIC_DESC_BOB = " " + PREFIX_ADDRESS + VALID_NRIC_BOB;
-
-    public static final String AGE_DESC_AMY = " " + PREFIX_ADDRESS + VALID_AGE_AMY;
-    public static final String AGE_DESC_BOB = " " + PREFIX_ADDRESS + VALID_AGE_BOB;
+    public static final String AGE_DESC_AMY = " " + PREFIX_AGE + VALID_AGE_AMY;
+    public static final String AGE_DESC_BOB = " " + PREFIX_AGE + VALID_AGE_BOB;
 
     public static final String RISK_DESC_AMY = " " + PREFIX_ADDRESS + VALID_RISKLEVEL_AMY;
     public static final String RISK_DESC_BOB = " " + PREFIX_ADDRESS + VALID_RISKLEVEL_BOB;
@@ -69,10 +67,10 @@ public class CommandTestUtil {
     public static final String TAG_DESC_FRIEND = " " + PREFIX_TAG + VALID_TAG_FRIEND;
     public static final String TAG_DESC_HUSBAND = " " + PREFIX_TAG + VALID_TAG_HUSBAND;
 
-    public static final String ELDERLY_DESC_AMY = " " + PREFIX_NRIC_ELDERLY + VALID_NAME_AMY;
-    public static final String ELDERLY_DESC_BOB = " " + PREFIX_NRIC_ELDERLY + VALID_NAME_BOB;
-    public static final String VOLUNTEER_DESC_AMY = " " + PREFIX_NRIC_VOLUNTEER + VALID_NAME_AMY;
-    public static final String VOLUNTEER_DESC_BOB = " " + PREFIX_NRIC_VOLUNTEER + VALID_NAME_BOB;
+    public static final String NRIC_ELDERLY_DESC_AMY = " " + PREFIX_NRIC_ELDERLY + VALID_NRIC_AMY;
+    public static final String NRIC_ELDERLY_DESC_BOB = " " + PREFIX_NRIC_ELDERLY + VALID_NRIC_BOB;
+    public static final String NRIC_VOLUNTEER_DESC_AMY = " " + PREFIX_NRIC_VOLUNTEER + VALID_NRIC_AMY;
+    public static final String NRIC_VOLUNTEER_DESC_BOB = " " + PREFIX_NRIC_VOLUNTEER + VALID_NRIC_BOB;
 
     public static final String INVALID_NAME_DESC = " " + PREFIX_NAME + "James&"; // '&' not allowed in names
     public static final String INVALID_PHONE_DESC = " " + PREFIX_PHONE + "911a"; // 'a' not allowed in phones

--- a/src/test/java/seedu/address/logic/commands/DeleteVolunteerCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteVolunteerCommandTest.java
@@ -1,0 +1,75 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TestUtil.getTypicalFriendlyLink;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Volunteer;
+import seedu.address.model.person.information.Nric;
+import seedu.address.testutil.TypicalVolunteers;
+
+public class DeleteVolunteerCommandTest {
+    private final Model model = new ModelManager(getTypicalFriendlyLink(), new UserPrefs());
+
+    @Test
+    public void execute_validNric_success() {
+        Volunteer volunteerToDelete = TypicalVolunteers.getTypicalVolunteers().get(0);
+        DeleteVolunteerCommand deleteVolunteerCommand = new DeleteVolunteerCommand(volunteerToDelete.getNric());
+
+        String expectedMessage = String.format(DeleteVolunteerCommand.MESSAGE_DELETE_SUCCESS, volunteerToDelete);
+
+        ModelManager expectedModel = new ModelManager(model.getFriendlyLink(), new UserPrefs());
+        expectedModel.deleteVolunteer(volunteerToDelete);
+
+        assertCommandSuccess(deleteVolunteerCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidNric_throwsCommandException() {
+        Nric invalidNric = new Nric("T9999999I");
+        DeleteVolunteerCommand deleteVolunteerCommand = new DeleteVolunteerCommand(invalidNric);
+
+        assertCommandFailure(deleteVolunteerCommand, model, Messages.MESSAGE_INVALID_VOLUNTEER_NRIC);
+    }
+    @Test
+    public void equals() {
+        Nric firstNric = new Nric("S1234567I");
+        Nric secondNric = new Nric("S7654321I");
+        DeleteVolunteerCommand deleteFirstCommand = new DeleteVolunteerCommand(firstNric);
+        DeleteVolunteerCommand deleteSecondCommand = new DeleteVolunteerCommand(secondNric);
+
+        // same object -> returns true
+        assertEquals(deleteFirstCommand, deleteFirstCommand);
+
+        // same values -> returns true
+        DeleteVolunteerCommand deleteFirstCommandCopy = new DeleteVolunteerCommand(firstNric);
+        assertEquals(deleteFirstCommand, deleteFirstCommandCopy);
+
+        // different types -> returns false
+        assertNotEquals(1, deleteFirstCommand);
+
+        // null -> returns false
+        assertNotEquals(null, deleteFirstCommand);
+
+        // different person -> returns false
+        assertNotEquals(deleteFirstCommand, deleteSecondCommand);
+    }
+
+    /**
+     * Updates {@code model}'s filtered list to show no one.
+     */
+    private void showNoPerson(Model model) {
+        model.updateFilteredPersonList(p -> false);
+
+        assertTrue(model.getFilteredPersonList().isEmpty());
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/ModelStub.java
+++ b/src/test/java/seedu/address/logic/commands/ModelStub.java
@@ -12,6 +12,7 @@ import seedu.address.model.pair.Pair;
 import seedu.address.model.person.Elderly;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Volunteer;
+import seedu.address.model.person.information.Nric;
 
 /**
  * A default model stub that have all the methods failing.
@@ -138,6 +139,11 @@ class ModelStub implements Model {
     }
 
     @Override
+    public Volunteer getVolunteerByNric(Nric nric) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
     public ObservableList<Person> getFilteredPersonList() {
         throw new AssertionError("This method should not be called.");
     }
@@ -174,7 +180,7 @@ class ModelStub implements Model {
      * Returns an unmodifiable view of the filtered volunteers list
      */
     @Override
-    public ObservableList<Person> getFilteredVolunteerList() {
+    public ObservableList<Volunteer> getFilteredVolunteerList() {
         throw new AssertionError("This method should not be called.");
     }
 

--- a/src/test/java/seedu/address/logic/parser/AddPairCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddPairCommandParserTest.java
@@ -1,10 +1,10 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.commands.CommandTestUtil.ELDERLY_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.NRIC_ELDERLY_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.NRIC_VOLUNTEER_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VOLUNTEER_DESC_BOB;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 
 import org.junit.jupiter.api.Test;
@@ -24,11 +24,11 @@ public class AddPairCommandParserTest {
         String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddPairCommand.MESSAGE_USAGE);
 
         // missing elderly prefix
-        assertParseFailure(parser, ELDERLY_DESC_AMY,
+        assertParseFailure(parser, NRIC_ELDERLY_DESC_AMY,
                 expectedMessage);
 
         // missing volunteer prefix
-        assertParseFailure(parser, VOLUNTEER_DESC_BOB,
+        assertParseFailure(parser, NRIC_VOLUNTEER_DESC_BOB,
                 expectedMessage);
 
         // all prefixes missing

--- a/src/test/java/seedu/address/logic/parser/DeleteVolunteerCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteVolunteerCommandParserTest.java
@@ -1,0 +1,37 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.CommandTestUtil.NRIC_VOLUNTEER_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NRIC_BOB;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.DeleteVolunteerCommand;
+import seedu.address.model.person.information.Nric;
+
+/**
+ * As we are only doing white-box testing, our test cases do not cover path variations
+ * outside the DeleteVolunteerCommand code. For example, inputs "1" and "1 abc" take the
+ * same path through the DeleteVolunteerCommand, and therefore we test only one of them.
+ * The path variation for those two cases occur inside the ParserUtil, and
+ * therefore should be covered by the ParserUtilTest.
+ */
+public class DeleteVolunteerCommandParserTest {
+
+    private DeleteVolunteerCommandParser parser = new DeleteVolunteerCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsDeleteVolunteerCommand() {
+        assertParseSuccess(parser, PREAMBLE_WHITESPACE + NRIC_VOLUNTEER_DESC_BOB,
+                new DeleteVolunteerCommand(new Nric(VALID_NRIC_BOB)));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        assertParseFailure(parser, "a",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteVolunteerCommand.MESSAGE_USAGE));
+    }
+}

--- a/src/test/java/seedu/address/model/FriendlyLinkTest.java
+++ b/src/test/java/seedu/address/model/FriendlyLinkTest.java
@@ -151,7 +151,7 @@ public class FriendlyLinkTest {
         }
 
         @Override
-        public List<Volunteer> getVolunteerList() {
+        public ObservableList<Volunteer> getVolunteerList() {
             return volunteers;
         }
 

--- a/src/test/java/seedu/address/model/FriendlyLinkTest.java
+++ b/src/test/java/seedu/address/model/FriendlyLinkTest.java
@@ -22,6 +22,7 @@ import javafx.collections.ObservableList;
 import seedu.address.model.pair.Pair;
 import seedu.address.model.person.Elderly;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.Volunteer;
 import seedu.address.model.person.exceptions.DuplicatePersonException;
 import seedu.address.testutil.PairBuilder;
 import seedu.address.testutil.PersonBuilder;
@@ -132,7 +133,7 @@ public class FriendlyLinkTest {
     private static class FriendlyLinkStub implements ReadOnlyFriendlyLink, ReadOnlyVolunteer, ReadOnlyElderly {
         private final ObservableList<Person> persons = FXCollections.observableArrayList();
         private final ObservableList<Elderly> elderly = FXCollections.observableArrayList();
-        private final ObservableList<Person> volunteers = FXCollections.observableArrayList();
+        private final ObservableList<Volunteer> volunteers = FXCollections.observableArrayList();
         private final ObservableList<Pair> pairs = FXCollections.observableArrayList();
 
         FriendlyLinkStub(Collection<Person> persons) {
@@ -150,7 +151,7 @@ public class FriendlyLinkTest {
         }
 
         @Override
-        public ObservableList<Person> getVolunteerList() {
+        public List<Volunteer> getVolunteerList() {
             return volunteers;
         }
 

--- a/src/test/java/seedu/address/testutil/TestUtil.java
+++ b/src/test/java/seedu/address/testutil/TestUtil.java
@@ -6,8 +6,11 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import seedu.address.commons.core.index.Index;
+import seedu.address.model.FriendlyLink;
 import seedu.address.model.Model;
+import seedu.address.model.person.Elderly;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.Volunteer;
 
 /**
  * A utility class for test cases.
@@ -51,5 +54,19 @@ public class TestUtil {
      */
     public static Person getPerson(Model model, Index index) {
         return model.getFilteredPersonList().get(index.getZeroBased());
+    }
+
+    /**
+     * Returns an {@code AddressBook} with all the typical persons.
+     */
+    public static FriendlyLink getTypicalFriendlyLink() {
+        FriendlyLink ab = new FriendlyLink();
+        for (Volunteer volunteer : TypicalVolunteers.getTypicalVolunteers()) {
+            ab.addVolunteer(volunteer);
+        }
+        for (Elderly elderly : TypicalElderlys.getTypicalElderlys()) {
+            ab.addElderly(elderly);
+        }
+        return ab;
     }
 }

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -60,6 +60,7 @@ public class TypicalPersons {
     private TypicalPersons() {} // prevents instantiation
 
     /**
+     * [TO REMOVE: Use TestUtil.getTypicalFriendlyLink() instead]
      * Returns an {@code AddressBook} with all the typical persons.
      */
     public static FriendlyLink getTypicalFriendlyLink() {


### PR DESCRIPTION
# Changes
- New `DeleteVolunteerCommand` and `DeleteVolunteerParserCommands` with respective test classes
- Added a new `getVolunteerByNric` method to `Model`, `ModelManager` and `FriendlyList`: since we will be searching for volunteers/elderlies by NRIC often, I thought this would be a good inclusion
  - To facilitate this, a new method `filter` was added to `UniquePersonList`
- Added a new `getTypicalFriendlyLink` method to `testutil/TestUtil` to replace the one in `testutil/TypicalPersons`
- Miscellaneous changes, such as changing `Person` to `Volunteer` where needed, and some minor naming change